### PR TITLE
Add support for contributte/console

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -108,3 +108,31 @@ $license = 'your_licence_key';
 
 \Contributte\NewRelic\Tracy\Bootstrap::init($appName, $license); // all parameters are optional
 ```
+
+## Console
+This step is not necessary, but recommended as it will give you a nice formated data even for console commands.
+You will need to add two packages, [contributte/console](https://github.com/contributte/console) and [contributte/event-dispatcher](https://github.com/contributte/event-dispatcher).
+```bash
+composer require contributte/console
+```
+
+```yaml
+extensions:
+  console: Contributte\Console\DI\ConsoleExtension(%consoleMode%)
+```
+
+```bash
+composer require contributte/event-dispatcher
+```
+
+```yaml
+extensions:
+  events: Contributte\EventDispatcher\DI\EventDispatcherExtension
+```
+
+Last step is registration of `NewRelicConsoleExtension`.
+
+```yaml
+extensions:
+  newrelic.console: Contributte\NewRelic\DI\NewRelicConsoleExtension
+```

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,10 @@
 		"csfix": "vendor/bin/phpcbf --standard=vendor/ninjify/coding-standard/ruleset-gamee.xml --extensions=php,phpt --tab-width=4 -sp src",
 		"tests": "vendor/bin/tester -s -p php --colors 1 -C tests/Cases"
 	},
+	"suggest": {
+		"contributte/console": "For a nice formated newrelic logs from console commands",
+		"contributte/event-dispatcher": "For a nice formated newrelic logs from console commands"
+	},
 	"archive": {
 		"exclude": [
 			".gitignore",

--- a/src/Callbacks/OnRequestCallback.php
+++ b/src/Callbacks/OnRequestCallback.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Contributte\NewRelic\Callbacks;
 
+use Contributte\NewRelic\Helpers;
 use Nette\Application\Application;
 use Nette\Application\Request;
 use Nette\Application\UI\Presenter;
@@ -38,6 +39,10 @@ class OnRequestCallback
 		$action = $request->getPresenterName();
 		if (isset($params[$this->actionKey])) {
 			$action = sprintf('%s:%s', $action, $params[$this->actionKey]);
+		}
+
+		if (PHP_SAPI === 'cli') {
+			$action = Helpers::getConsoleCommand();
 		}
 
 		newrelic_name_transaction($action);

--- a/src/DI/NewRelicConsoleExtension.php
+++ b/src/DI/NewRelicConsoleExtension.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contributte\NewRelic\DI;
+
+use Contributte\Console\Application;
+use Contributte\NewRelic\Events\Listeners\ConsoleListener;
+use Contributte\NewRelic\Tracy\Bootstrap;
+use Nette\DI\CompilerExtension;
+use Nette\DI\ServiceCreationException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class NewRelicConsoleExtension extends CompilerExtension
+{
+
+	/**
+	 * @var bool
+	 */
+	private $skipIfIsDisabled;
+
+	/**
+	 * @param bool $skipIfIsDisabled
+	 */
+	public function __construct($skipIfIsDisabled = false)
+	{
+		$this->skipIfIsDisabled = $skipIfIsDisabled;
+	}
+
+	public function loadConfiguration()
+	{
+		if (!class_exists(Application::class)) {
+			throw new ServiceCreationException(sprintf('Missing "%s" service', Application::class));
+		}
+
+		if (!interface_exists(EventDispatcherInterface::class)) {
+			throw new ServiceCreationException(sprintf('Missing "%s" service', EventDispatcherInterface::class));
+		}
+
+		$config = $this->getConfig();
+		if ($this->skipIfIsDisabled && (!extension_loaded('newrelic') || !Bootstrap::isEnabled())) {
+			return;
+		}
+
+		if (isset($config['enabled']) && !$config['enabled']) {
+			return;
+		}
+
+		$this->setupConsoleListener();
+	}
+
+	private function setupConsoleListener()
+	{
+		$builder = $this->getContainerBuilder();
+
+		$builder->addDefinition($this->prefix('consoleListener'))
+			->setClass(ConsoleListener::class);
+	}
+
+}

--- a/src/Events/Listeners/ConsoleListener.php
+++ b/src/Events/Listeners/ConsoleListener.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contributte\NewRelic\Events\Listeners;
+
+use Contributte\NewRelic\Helpers;
+use Symfony\Component\Console;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ConsoleListener implements EventSubscriberInterface
+{
+
+	public static function getSubscribedEvents(): array
+	{
+		return [
+			Console\ConsoleEvents::COMMAND => 'onCommand',
+			Console\ConsoleEvents::ERROR => 'onError',
+		];
+	}
+
+
+	public function onCommand(Console\Event\ConsoleCommandEvent $event)
+	{
+		newrelic_background_job(true);
+		newrelic_name_transaction(Helpers::getConsoleCommand());
+		newrelic_disable_autorum();
+	}
+
+
+	public function onError(Console\Event\ConsoleErrorEvent $event)
+	{
+		newrelic_notice_error($event->getError()->getMessage(), $event->getError());
+	}
+
+}

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contributte\NewRelic;
+
+class Helpers
+{
+
+	public static function getConsoleCommand(): string
+	{
+		return trim('$ ' . basename($_SERVER['argv'][0]) . ' ' . implode(' ', array_slice($_SERVER['argv'], 1)));
+	}
+
+}


### PR DESCRIPTION
Package was build mostly for kdyby/console and for thet reason it is not working that good.
All callbacks/events are set on `Nette\Application\Application` and it works fine, but only for request over index.php.

Contributte/console is using own `Application`, but it is not child of `Nette\Application\Application`. It is reason why it is not possible to see console request/errors in newrelic as it never calls anything from `OnRequestCallback`.

This change can fix it as it is using symfony console events for communication with newrelic.